### PR TITLE
Improved JavaDoc for DiskMark, Util, App, and Persist Package Info

### DIFF
--- a/src/edu/touro/mco152/bm/App.java
+++ b/src/edu/touro/mco152/bm/App.java
@@ -243,6 +243,12 @@ public class App {
         worker.cancel(true);
     }
 
+    /**
+     * Starts benchmark run using current disk configuration
+     * If benchmark currently running, warning is logged and method is aborted
+     * Sets up area on disk and updates state
+     * Sets up diskWorker and Swing worker thread
+     */
     public static void startBenchmark() {
 
         //1. check that there isn't already a worker in progress

--- a/src/edu/touro/mco152/bm/DiskMark.java
+++ b/src/edu/touro/mco152/bm/DiskMark.java
@@ -4,6 +4,7 @@ import java.text.DecimalFormat;
 
 /**
  * Tracks and records progress as a disk read or write is being executed
+ * Each Mark represents a single measurement taken during a Benchmark run
  */
 public class DiskMark {
 

--- a/src/edu/touro/mco152/bm/Util.java
+++ b/src/edu/touro/mco152/bm/Util.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Utility methods for jDiskMark
-
+ * including random number generator, disk and device info retrieval.
  */
 public class Util {
 
@@ -36,7 +36,13 @@ public class Util {
         return (path.delete());
     }
 
-
+    /**
+     * Generates random Int in given range
+     *
+     * @param min minimum value (inclusive)
+     * @param max maximum value (inclusive)
+     * @return random integer between min and max
+     */
     public static int randInt(int min, int max) {
 
         // Usually this can be a field rather than a method variable

--- a/src/edu/touro/mco152/bm/persist/package-info.java
+++ b/src/edu/touro/mco152/bm/persist/package-info.java
@@ -1,6 +1,8 @@
 /**
  * A container for utility classes that help with handling persistent
- * data. This data can be used to gather statistical information
+ * data. Data includes start/end time of run, IOMode, and disk info.
+ * Using JPA and Derby to store Data in database in .jDiskMark.
+ * This data can be used to gather statistical information
  * about the machine being tested.
  */
 package edu.touro.mco152.bm.persist;


### PR DESCRIPTION
Added and edited class-level and method-level Java-docs in DiskMark, Util, App, and Persist Package info. Java-docs include descriptions of classes/methods and if relevant, params and return values.